### PR TITLE
can mark answers as helpful

### DIFF
--- a/client/src/widgets/QA/Answer.jsx
+++ b/client/src/widgets/QA/Answer.jsx
@@ -1,7 +1,16 @@
 import React, {useState, useEffect} from "react";
 import axios from 'axios';
 
-function Answer ({answer}) {
+function Answer ({answer, markHelpful, helpfulQA, setHelpfulQA}) {
+
+  const [helpfulness, setHelpfulness] = useState(answer.helpfulness);
+
+  const markAnswerHelpful = function () {
+    if (markHelpful(answer.id, helpfulQA, setHelpfulQA)) {
+      axios.post(`/markAnswerHelpful`, {answer_id: answer.id})
+      .then(() => setHelpfulness(helpfulness + 1));
+    }
+  }
 
   let answerDate = new Date(answer.date);
   const months = ["January","February","March","April","May","June","July",
@@ -14,7 +23,7 @@ function Answer ({answer}) {
       </div>
       <div>
         by {answer.answerer_name}, {months[answerDate.getMonth()]} {answerDate.getDate()}, {answerDate.getFullYear()} |
-        Helpful? Yes{`(${answer.helpfulness})`} |
+        <span onClick={() => {markAnswerHelpful()}}> Helpful? Yes{`(${helpfulness})`}</span> |
         Report
       </div>
       <div>

--- a/client/src/widgets/QA/AnswerList.jsx
+++ b/client/src/widgets/QA/AnswerList.jsx
@@ -2,12 +2,13 @@ import React, {useState, useEffect} from "react";
 import axios from 'axios';
 import Answer from './Answer.jsx';
 
-function AnswerList ({answers}) {
+function AnswerList ({answers, markHelpful, helpfulQA, setHelpfulQA}) {
   let answerSlice = answers.slice(0, 2);
   return(
     <div>
       {answerSlice.map((answer, index) => {
-        return (<Answer answer={answer} key={index}/>)
+        return (<Answer answer={answer} markHelpful={markHelpful} helpfulQA={helpfulQA}
+          setHelpfulQA={setHelpfulQA} key={index}/>)
       })}
     </div>
   );

--- a/client/src/widgets/QA/Question.jsx
+++ b/client/src/widgets/QA/Question.jsx
@@ -24,14 +24,13 @@ function Question ({question, prodName, markHelpful, helpfulQA, setHelpfulQA}) {
 
 let displayAnswers = (<div></div>);
 if (answers.length > 0) {
-  displayAnswers = <AnswerList answers={answers} />
+  displayAnswers = <AnswerList answers={answers} markHelpful={markHelpful} helpfulQA={helpfulQA} setHelpfulQA={setHelpfulQA}/>
 }
 
   return(
     <div>
       <div>
-        Q: {question.question_body} |
-        <span onClick={() => markQuestionHelpful()}>Helpful? Yes{`(${helpfulness})`}</span> |
+        Q: {question.question_body} | <span onClick={() => markQuestionHelpful()}> Helpful? Yes{`(${helpfulness})`}</span> |
         <span onClick={() => setShowAnswerModal(true)}> Add Answer</span>
       </div>
       {displayAnswers}


### PR DESCRIPTION
Now all questions and answers can be marked helpful once. Persists across refreshes due to local storage. 
Clicking the "helpful" link will increment the number displayed on the page and send the put request to the API. 