### PR TITLE
Fixed bug so now questions and answers match current product

### DIFF
--- a/client/src/widgets/QA/AnswerList.jsx
+++ b/client/src/widgets/QA/AnswerList.jsx
@@ -4,7 +4,12 @@ import Answer from './Answer.jsx';
 
 function AnswerList ({answers, markHelpful, helpfulQA, setHelpfulQA}) {
 
-  let [shownAnswers, setShownAnswers] = useState(answers.slice(0, 2));
+  // let [shownAnswers, setShownAnswers] = useState(answers.slice(0, 2));
+  let [shownAnswers, setShownAnswers] = useState([]);
+
+  useEffect(() => {
+    setShownAnswers(answers.slice(0, 2));
+  }, [answers]);
 
   const displayCSS = {
     color : "black",

--- a/client/src/widgets/QA/QA.jsx
+++ b/client/src/widgets/QA/QA.jsx
@@ -12,7 +12,6 @@ function QA ({currentProduct}) {
     margin: "2vh",
     fontFamily: "Arial"
   }
-
   const [questions, setQuestions] = useState([]);
   const [showQuestionModal, setShowQuestionModal] = useState(false);
   const [helpfulQA, setHelpfulQA] = useState(JSON.parse(localStorage.getItem('helpfulQA')) || []);
@@ -21,7 +20,7 @@ function QA ({currentProduct}) {
   .then((res) => {
     setQuestions(res.data.results);
   })
-}, []);
+}, [currentProduct]);
 
   const markHelpful = function (itemID, helpfulQA, setHelpfulQA) {
     if (helpfulQA.includes(itemID)) {
@@ -42,7 +41,8 @@ function QA ({currentProduct}) {
         prodName={currentProduct.name}
         markHelpful={markHelpful}
         helpfulQA={helpfulQA}
-        setHelpfulQA={setHelpfulQA}/>
+        setHelpfulQA={setHelpfulQA}
+        currentProduct={currentProduct}/>
         <button onClick={() => setShowQuestionModal(true)}>Add a Question</button>
         {showQuestionModal && createPortal(
           <QuestionModal productID={currentProduct.id} onClose={() => setShowQuestionModal(false)}

--- a/client/src/widgets/QA/QA.jsx
+++ b/client/src/widgets/QA/QA.jsx
@@ -54,7 +54,12 @@ function QA ({currentProduct}) {
   }
   return(
     <div>
-      No Questions Yet... Add One!
+      <button onClick={() => setShowQuestionModal(true)}>Add a Question</button>
+        {showQuestionModal && createPortal(
+          <QuestionModal productID={currentProduct.id} onClose={() => setShowQuestionModal(false)}
+          prodName={currentProduct.name}/>,
+          document.getElementById("modal")
+        )}
     </div>
   )
 

--- a/client/src/widgets/QA/QA.test.js
+++ b/client/src/widgets/QA/QA.test.js
@@ -22,8 +22,8 @@ test('question modal shows fields and a close button', () => {
     <QuestionModal onClose={handleClose} productID={37311} />
   )
 
-  expect(screen.getByLabelText('Your Question:')).toBeTruthy();
-  expect(screen.getByLabelText('Your Display Name:')).toBeTruthy();
+  expect(screen.getByText('Your Question:')).toBeTruthy();
+  expect(screen.getByText('Your Display Name:')).toBeTruthy();
   expect(screen.getByText('For privacy reasons, do not use your full name or email address')).toBeTruthy();
 
 

--- a/client/src/widgets/QA/QuestionList.jsx
+++ b/client/src/widgets/QA/QuestionList.jsx
@@ -3,15 +3,19 @@ import axios from 'axios';
 import Question from './Question.jsx';
 import QuestionSearch from './QuestionSearch.jsx';
 
-function QuestionList ({questions, prodName, markHelpful, helpfulQA, setHelpfulQA}) {
-
+function QuestionList ({questions, prodName, markHelpful, helpfulQA, setHelpfulQA, currentProduct}) {
   const listStyle = {
     margin: "2vh",
     fontFamily: "Arial"
   }
 
+  let [shownQuestions, setShownQuestions] = useState([]);
+  // let [shownQuestions, setShownQuestions] = useState(questions.slice(0, 4));
 
-  let [shownQuestions, setShownQuestions] = useState(questions.slice(0, 4));
+  useEffect(() => {
+    setShownQuestions(questions.slice(0, 4));
+  }, [questions])
+
   let [filterString, setFilterString] = useState("");
 
   const displayCSS = {
@@ -27,12 +31,12 @@ function QuestionList ({questions, prodName, markHelpful, helpfulQA, setHelpfulQ
   let shownCSS = displayCSS;
 
   let additionalQuestionButton = (<div></div>);
-
   if (questions.length > 4) {
-    additionalQuestionButton = (<span onClick={() => setShownQuestions(questions)}>More Answered Questions</span>);
+    additionalQuestionButton = (<span onClick={() => {
+      setShownQuestions(questions)}}>More Answered Questions</span>);
     if (shownQuestions.length > 4) {
       shownCSS = scrollCSS;
-      additionalQuestionButton = (<span onClick={() => setShownQuestions(questions.slice(0, 4))}>Collapse Question List</span>)
+      additionalQuestionButton = (<span onClick={() => setShownQuestions(shownQuestions.slice(0, 4))}>Collapse Question List</span>)
     }
   }
 

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -94,7 +94,7 @@ module.exports.reviewMetadata = (product_id) => {
 //Questions and Answers API
 
 module.exports.listQuestions = function (product_id) {
-  return axios.get(`${url}/qa/questions?product_id=${product_id}&page=1&count=100`, {
+  return axios.get(`${url}/qa/questions?product_id=${product_id}&page=1&count=1000`, {
     headers: {
       Authorization: process.env.API_KEY
     }


### PR DESCRIPTION
By using useEffect to update state whenever the currentproduct is changed the questions and answers match the product instead of manually needing a refresh by expanding and collapsing the question list. 