### PR TITLE
Question search now searches all questions, not just displayed 4 questions

### DIFF
--- a/client/src/widgets/QA/QuestionList.jsx
+++ b/client/src/widgets/QA/QuestionList.jsx
@@ -40,12 +40,17 @@ function QuestionList ({questions, prodName, markHelpful, helpfulQA, setHelpfulQ
     }
   }
 
+  let display = shownQuestions;
+  if (filterString.length > 2) {
+    display = questions;
+  }
+
 
   return(
     <div style = {listStyle}>
       <QuestionSearch filterString={filterString} setFilterString={setFilterString}/>
     <div id="questionList" style={shownCSS}>
-      {shownQuestions.map((question, index) => {
+      {display.map((question, index) => {
         if (question.question_body.toLowerCase().includes(filterString.toLowerCase())) {
           return (<Question question={question}
             prodName={prodName}


### PR DESCRIPTION
The question search should now be working as expected.
Previously it would just search from the questions displayed on the screen, typically the 4 initially displayed questions.
It would only search all the questions if the "show all questions" button was pressed.
Now it properly searches from all the questions even if the button is not pressed. 