### PR TITLE
added photo modal to photos displayed in answer

### DIFF
--- a/client/src/widgets/QA/Answer.jsx
+++ b/client/src/widgets/QA/Answer.jsx
@@ -1,5 +1,6 @@
 import React, {useState, useEffect} from "react";
 import axios from 'axios';
+import AnswerPhotoModal from './AnswerPhotoModal.jsx'
 
 function Answer ({answer, markHelpful, helpfulQA, setHelpfulQA}) {
 
@@ -18,20 +19,6 @@ function Answer ({answer, markHelpful, helpfulQA, setHelpfulQA}) {
     padding: "1vh",
   }
 
-  // let imgStyle;
-  // if (zoomedIn) {
-  //   imgStyle = {
-  //     margin: "2vh",
-  //     transition: "transform 0.25s ease",
-  //     transform: "scale(2)",
-  //     cursor: "zoom-out",
-  //   }} else {
-  //     imgStyle = {
-  //       margin: "2vh",
-  //       transition: "transform 0.25s ease",
-  //       cursor: "zoom-in",
-  //     }
-  // }
 
   let defaultImgStyle = {
     margin: "2vh",
@@ -86,10 +73,13 @@ function Answer ({answer, markHelpful, helpfulQA, setHelpfulQA}) {
       <div style={bodyStyle}>
         A: {answer.body}
       </div>
-      <div>
+      <div style={{display: "flex", flexDirection: "row"}}>
         {answer.photos.map((picture, index) => {
+          // return (
+          //   <img src={picture} style={zoomedImages[index] ? defaultImgStyle : zoomImgStyle} height="50px" key={index} onClick={() => {zoomImage(index)}}></img>
+          // )
           return (
-            <img src={picture} style={zoomedImages[index] ? defaultImgStyle : zoomImgStyle} height="50px" key={index} onClick={() => {zoomImage(index)}}></img>
+            <AnswerPhotoModal photo={picture} key={index}/>
           )
         })}
       </div>

--- a/client/src/widgets/QA/AnswerPhotoModal.jsx
+++ b/client/src/widgets/QA/AnswerPhotoModal.jsx
@@ -1,0 +1,53 @@
+import React, {useState, useEffect} from "react";
+import axios from 'axios';
+
+function AnswerPhotoModal ({ photo }) {
+
+  const [zoomedIn, setZoomedIn] = useState(false);
+
+  const closeCSS = {
+    "position": "absolute",
+    "top": "15px",
+    "right": "35px",
+    "color": "#f1f1f",
+    "fontSize": "20px",
+    "fontWeight": "bold",
+    "transition": "0.3s",
+  }
+
+  if (zoomedIn) {
+    return(
+      <div>
+      <div style={{"display": "flex",
+      "flexDirection": "column",
+      "justifyContent": "center",
+      "alignItems": "left",
+      "boxShadow": "rgba(100, 100, 111, 0.3) 0px 7px 29px 0px",
+      "backgroundColor": "white",
+      "border": "2px solid rgb(240, 240, 240)",
+      "borderRadius": "12px",
+      "padding": "1vh",
+      "paddingLeft": "20vh",
+      "paddingRight": "20vh",
+      "position": "fixed",
+      "top": "5vh",
+      "left": "40vh",
+      "right": "20vh",
+      "bottom": "5vh"}}>
+        <span style={closeCSS} onClick={() => setZoomedIn(false)}>&times;</span>
+        <img src={photo}></img>
+      </div>
+
+      <img src={photo} style = {{height: "10vh"}}onClick={() => setZoomedIn(true)}></img>
+    </div>
+    );
+  } else {
+    return <div>
+      <img src={photo} style = {{height: "10vh"}}onClick={() => setZoomedIn(true)}></img>
+    </div>
+  }
+
+
+}
+
+export default AnswerPhotoModal;


### PR DESCRIPTION
Now when you click on a photo displayed in the answers, the photo will display in a modal, with an "x" button to exit the modal. 

One small bug - if you click on multiple images, a modal will pop up for each image, but this is relatively low priority. The bug does not interfere with the core experience. 